### PR TITLE
fixed missing cytoscape dependencies in POM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ buildNumber.properties
 *.pdf
 *.vsdx
 *.indd
+zugzwang.iml
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<properties>
 		<bundle.symbolicName>org.cytoscape.zugzwang</bundle.symbolicName>
 		<bundle.namespace>org.cytoscape.zugzwang.internal</bundle.namespace>
-		<cytoscape.api>3.3.0-SNAPSHOT</cytoscape.api>
+		<cytoscape.api>3.3.0</cytoscape.api>
 		<project.version>0.1.0</project.version>
 		<timestamp>${maven.build.timestamp}</timestamp>
 		<jogl.version>2.3.1</jogl.version>


### PR DESCRIPTION
Cytoscape 3.3.0-SNAPSHOT does not exist any more, changed to 3.3.0 in release
